### PR TITLE
Audit log and change in Core DISALED states and lowered NX domain log events

### DIFF
--- a/core.go
+++ b/core.go
@@ -3,7 +3,6 @@ package main
 import (
 	"io/ioutil"
 	"net/http"
-	"runtime"
 	"strconv"
 	"time"
 
@@ -196,11 +195,13 @@ func readCacheFile(file string) (*CoreCache, error) {
 	return cacheData, nil
 }
 
+/* TODO: Make configurable and controllable from the outside
 func logDebugMemory(label string) {
 	var mem runtime.MemStats
 	runtime.ReadMemStats(&mem)
 	logger.Debug(label+"- Alloc:%d, TotalA:%d, HeapA:%d, HeapSys:%d", mem.Alloc, mem.TotalAlloc, mem.HeapAlloc, mem.HeapSys)
 }
+*/
 
 func prepareRequest(uri string) *http.Request {
 	req, _ := http.NewRequest("GET", settings.CACHE_URL+uri, nil)

--- a/handler.go
+++ b/handler.go
@@ -61,10 +61,8 @@ func NewHandler() *GODNSHandler {
 		panic("Invalid cache backend")
 	}
 
-	if settings.LOCAL_RESOLVER {
-		listCache = NewListCache()
-		StartCoreClient(listCache)
-	}
+	listCache = NewListCache()
+	StartCoreClient(listCache)
 
 	resolver.init()
 
@@ -97,7 +95,7 @@ func (h *GODNSHandler) do(Net string, w dns.ResponseWriter, req *dns.Msg) {
 	mesg, err := h.resolver.Lookup(Net, req, w.RemoteAddr(), h.oraculumCache, h.listCache)
 
 	if err != nil {
-		logger.Warn("Resolve query error %s", err)
+		logger.Debug("Resolve query error %s", err)
 		dns.HandleFailed(w, req)
 		return
 	}

--- a/main.go
+++ b/main.go
@@ -12,10 +12,15 @@ import (
 
 var (
 	logger *GoDNSLogger
+	auditor *GoDNSLogger
 )
 
 func main() {
+	// General system messages, errors...
 	initLogger()
+	// JSON auditing block events {"client_ip": "<IP>", "domain": "<domain>", "action": "<audit/block>"}
+	initAuditor()
+
 	// Profiler
 	if (settings.LogLevel() == LevelDebug) {
 		go func() {
@@ -57,15 +62,27 @@ func initLogger() {
 	logger = NewLogger()
 
 	if settings.LOG_STDOUT {
-		logger.SetLogger("console", nil)
+		logger.SetLogger("console", nil, true)
 	}
 
 	if settings.LOG_FILE != "" {
 		config := map[string]interface{}{"file": settings.LOG_FILE}
-		logger.SetLogger("file", config)
+		logger.SetLogger("file", config, true)
 	}
 
 	logger.SetLevel(settings.LogLevel())
+}
+
+
+func initAuditor() {
+	auditor = NewLogger()
+
+	if settings.AUDIT_FILE != "" {
+		config := map[string]interface{}{"file": settings.AUDIT_FILE}
+		auditor.SetLogger("file", config, false)
+	}
+
+	auditor.SetLevel(settings.AuditLevel())
 }
 
 func init() {

--- a/resolver.go
+++ b/resolver.go
@@ -64,7 +64,7 @@ func (r *Resolver) Lookup(net string, req *dns.Msg, remoteAddress net.Addr, orac
 		// that it has been verified no such domain exists and ask other resolvers
 		// would make no sense. See more about #20
 		if r != nil && r.Rcode != dns.RcodeSuccess {
-			logger.Warn("%s failed to get an valid answer on %s", qname, nameserver)
+			logger.Debug("%s failed to get an valid answer on %s", qname, nameserver)
 			if r.Rcode == dns.RcodeServerFailure {
 				return
 			}


### PR DESCRIPTION
# Audit log
Audit log, adds SINKIT_AUDIT_FILE=<path to file> and SINKIT_AUDIT_LEVEL=ALL|AUDITED|BLOCKED. The default is ALL. The log message keeps format:

```
{"timestamp":"2017/09/23 14:20:33.181003","client_ip":"127.0.0.1","domain":"zladomena.cz","action":"block"}
{"timestamp":"2017/09/23 14:20:35.713429","client_ip":"127.0.0.1","domain":"karms.biz","action":"audit"}
```
**Note that if *SINKIT_AUDIT_FILE* is unspecified, no auditing takes place, not even on stdout.**

# Error code or network error no longer makes Core DISABLED
Furthermore, Error code or network error in communication with Core is no loger a factor in DISABLED decision making.

# Testing the RC
@robcza , ```karm/sinkit-godns:1.0.3-RC4```