### PR TITLE
SINKIT_BACKEND_RESOLVERS_TCP_ONLY=<true|false>

### DIFF
--- a/resolver.go
+++ b/resolver.go
@@ -33,6 +33,11 @@ var nameservers []string
 // in every second, and return as early as possible (have an answer).
 // It returns an error if no request has succeeded.
 func (r *Resolver) Lookup(net string, req *dns.Msg, remoteAddress net.Addr, oraculumCache Cache, caches *ListCache) (message *dns.Msg, err error) {
+
+	if(settings.BACKEND_RESOLVERS_TCP_ONLY) {
+		net = "tcp"
+	}
+
 	c := &dns.Client{
 		Net:          net,
 		ReadTimeout:  r.Timeout(),

--- a/settings.go
+++ b/settings.go
@@ -59,6 +59,7 @@ type Settings struct {
 	CLIENT_ID_HEADER                string
 	BACKEND_RESOLVERS               []string
 	BACKEND_RESOLVERS_EXCLUSIVELY   bool
+	BACKEND_RESOLVERS_TCP_ONLY      bool
 	ORACULUM_API_FIT_TIMEOUT        int64
 	ORACULUM_SLEEP_WHEN_DISABLED    int64
 	ORACULUM_API_TIMEOUT            int64


### PR DESCRIPTION
Doesn't seem to bring any regression with Unbound. Not tested with Bind.